### PR TITLE
Add configurable temporal models for F0 sequence modeling

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -8,7 +8,17 @@ train_data: "Data/train_list.txt"
 val_data: "Data/val_list.txt"
 num_workers: 16
 
-  
+model_params:
+  num_class: 1
+  sequence_model:
+    model_type: transformer
+    num_layers: 4
+    dropout: 0.1
+    nhead: 8
+    dim_feedforward: 1536
+    max_len: 2048
+
+
 optimizer_params:
   lr: 0.0003
   

--- a/README.md
+++ b/README.md
@@ -30,10 +30,13 @@ python train.py --config_path ./Configs/config.yml
 ```
 Please specify the training and validation data in `config.yml` file. The data list format needs to be `filename.wav|anything`, see [train_list.txt](https://github.com/yl4579/StarGANv2-VC/blob/main/Data/train_list.txt) as an example (a subset of VCTK). Note that you can put anything after the filename because the training labels are generated ad-hoc.
 
-Checkpoints and Tensorboard logs will be saved at `log_dir`. To speed up training, you may want to make `batch_size` as large as your GPU RAM can take. 
+Checkpoints and Tensorboard logs will be saved at `log_dir`. To speed up training, you may want to make `batch_size` as large as your GPU RAM can take.
+
+### Sequence modelling options
+The default configuration now employs a Transformer encoder on top of the convolutional stack to provide stronger long-term temporal context and reduce octave jumps. You can switch between a deeper bidirectional LSTM and the Transformer backend by editing `model_params.sequence_model` in [Configs/config.yml](Configs/config.yml). The section exposes typical hyper-parameters (number of layers, attention heads, feed-forward width, etc.) so you can tailor the temporal model to your dataset.
 
 ### IMPORTANT: DATA FOLDER NEEDS WRITE PERMISSION
-Since both `harvest` and `dio` are relatively slow, we do have to save the computed F0 ground truth for later use. In [meldataset.py](https://github.com/yl4579/PitchExtractor/blob/main/meldataset.py#L77-L89), it will write the computed F0 curve `_f0.npy` for each `.wav` file. This requires write permission in your data folder. 
+Since both `harvest` and `dio` are relatively slow, we do have to save the computed F0 ground truth for later use. In [meldataset.py](https://github.com/yl4579/PitchExtractor/blob/main/meldataset.py#L77-L89), it will write the computed F0 curve `_f0.npy` for each `.wav` file. This requires write permission in your data folder.
 
 ### F0 Computation Details
 `meldataset.MelDataset` now supports a cascade of runtime-selectable F0 backends. The default configuration uses PyWorld's `harvest` followed by `dio`, mirroring the original behaviour, but you can enable neural or classical trackers such as TorchCrepe (PyTorch CREPE) and Praat/Parselmouth by editing `dataset_params.f0_params` in [Configs/config.yml](Configs/config.yml). Backends are evaluated in the order defined by `backend_order`, and each backend may be toggled on/off or customised individually (for example, to adjust TorchCrepe's model size or Praat's pitch range).

--- a/model.py
+++ b/model.py
@@ -4,6 +4,8 @@ Kum et al. - "Joint Detection and Classification of Singing Voice Melody Using
 Convolutional Recurrent Neural Networks" (2019)
 Link: https://www.semanticscholar.org/paper/Joint-Detection-and-Classification-of-Singing-Voice-Kum-Nam/60a2ad4c7db43bace75805054603747fcd062c0d
 """
+import math
+
 import torch
 from torch import nn
 
@@ -12,9 +14,10 @@ class JDCNet(nn.Module):
     """
     Joint Detection and Classification Network model for singing voice melody.
     """
-    def __init__(self, num_class=722, leaky_relu_slope=0.01):
+    def __init__(self, num_class=722, leaky_relu_slope=0.01, sequence_model_config=None):
         super().__init__()
         self.num_class = num_class
+        sequence_model_config = sequence_model_config or {}
 
         # input = (b, 1, 31, 513), b = batch size
         self.conv_block = nn.Sequential(
@@ -53,21 +56,18 @@ class JDCNet(nn.Module):
             nn.Dropout(p=0.5),
         )
 
-        # input: (b, 31, 512) - resized from (b, 256, 31, 2)
-        self.bilstm_classifier = nn.LSTM(
-            input_size=512, hidden_size=256,
-            batch_first=True, dropout=0.3, bidirectional=True)  # (b, 31, 512)
+        sequence_model_config.setdefault('input_size', 512)
+        self.sequence_classifier = SequenceModel(**sequence_model_config)
+        self.sequence_detector = SequenceModel(**sequence_model_config)
 
-        # input: (b, 31, 512) - resized from (b, 256, 31, 2)
-        self.bilstm_detector = nn.LSTM(
-            input_size=512, hidden_size=256,
-            batch_first=True, dropout=0.3, bidirectional=True)  # (b, 31, 512)
+        classifier_dim = self.sequence_classifier.output_dim
+        detector_dim = self.sequence_detector.output_dim
 
-        # input: (b * 31, 512)
-        self.classifier = nn.Linear(in_features=512, out_features=self.num_class)  # (b * 31, num_class)
+        # input: (b * 31, classifier_dim)
+        self.classifier = nn.Linear(in_features=classifier_dim, out_features=self.num_class)  # (b * 31, num_class)
 
-        # input: (b * 31, 512)
-        self.detector = nn.Linear(in_features=512, out_features=2)  # (b * 31, 2) - binary classifier
+        # input: (b * 31, detector_dim)
+        self.detector = nn.Linear(in_features=detector_dim, out_features=2)  # (b * 31, 2) - binary classifier
 
         # initialize weights
         self.apply(self.init_weights)
@@ -91,9 +91,9 @@ class JDCNet(nn.Module):
         
         # (b, 256, 31, 2) => (b, 31, 256, 2) => (b, 31, 512)
         classifier_out = poolblock_out.permute(0, 2, 1, 3).contiguous().view((-1, seq_len, 512))
-        classifier_out, _ = self.bilstm_classifier(classifier_out)  # ignore the hidden states
+        classifier_out = self.sequence_classifier(classifier_out)
 
-        classifier_out = classifier_out.contiguous().view((-1, 512))  # (b * 31, 512)
+        classifier_out = classifier_out.contiguous().view((-1, classifier_out.shape[-1]))  # (b * 31, hidden)
         classifier_out = self.classifier(classifier_out)
         classifier_out = classifier_out.view((-1, seq_len, self.num_class))  # (b, 31, num_class)
 
@@ -110,9 +110,9 @@ class JDCNet(nn.Module):
 
         # (b, 256, 31, 2) => (b, 31, 256, 2) => (b, 31, 512)
         detector_out = detector_out.permute(0, 2, 1, 3).contiguous().view((-1, seq_len, 512))
-        detector_out, _ = self.bilstm_detector(detector_out)  # (b, 31, 512)
+        detector_out = self.sequence_detector(detector_out)  # (b, 31, hidden)
 
-        detector_out = detector_out.contiguous().view((-1, 512))
+        detector_out = detector_out.contiguous().view((-1, detector_out.shape[-1]))
         detector_out = self.detector(detector_out)
         detector_out = detector_out.view((-1, seq_len, 2)).sum(axis=-1)  # binary classifier - (b, 31, 2)
         
@@ -173,3 +173,84 @@ class ResBlock(nn.Module):
         else:
             x = self.conv(x) + x
         return x
+
+
+class SinusoidalPositionalEncoding(nn.Module):
+    """Sinusoidal positional encoding compatible with batch-first inputs."""
+
+    def __init__(self, d_model: int, max_len: int = 2000):
+        super().__init__()
+        pe = torch.zeros(max_len, d_model)
+        position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
+        div_term = torch.exp(torch.arange(0, d_model, 2).float() * (-math.log(10000.0) / d_model))
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        pe = pe.unsqueeze(0)
+        self.register_buffer('pe', pe)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        seq_len = x.size(1)
+        return x + self.pe[:, :seq_len]
+
+
+class SequenceModel(nn.Module):
+    """Flexible temporal modeling block supporting BiLSTM and Transformer backends."""
+
+    def __init__(
+        self,
+        input_size: int,
+        model_type: str = "bilstm",
+        hidden_size: int = 384,
+        num_layers: int = 2,
+        dropout: float = 0.3,
+        bidirectional: bool = True,
+        nhead: int = 8,
+        dim_feedforward: int = 1024,
+        max_len: int = 2000,
+    ):
+        super().__init__()
+        self.model_type = model_type.lower()
+        self.input_size = input_size
+        self.hidden_size = hidden_size
+        self.bidirectional = bidirectional
+        self.num_layers = num_layers
+
+        if self.model_type == "bilstm":
+            lstm_dropout = dropout if num_layers > 1 else 0.0
+            self.model = nn.LSTM(
+                input_size=input_size,
+                hidden_size=hidden_size,
+                num_layers=num_layers,
+                dropout=lstm_dropout,
+                batch_first=True,
+                bidirectional=bidirectional,
+            )
+            self._output_dim = hidden_size * (2 if bidirectional else 1)
+        elif self.model_type == "transformer":
+            self.pos_encoding = SinusoidalPositionalEncoding(input_size, max_len=max_len)
+            encoder_layer = nn.TransformerEncoderLayer(
+                d_model=input_size,
+                nhead=nhead,
+                dim_feedforward=dim_feedforward,
+                dropout=dropout,
+                batch_first=True,
+                activation="gelu",
+            )
+            self.model = nn.TransformerEncoder(encoder_layer, num_layers=num_layers)
+            self.layer_norm = nn.LayerNorm(input_size)
+            self._output_dim = input_size
+        else:
+            raise ValueError(f"Unsupported sequence model type: {model_type}")
+
+    @property
+    def output_dim(self) -> int:
+        return self._output_dim
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.model_type == "bilstm":
+            x, _ = self.model(x)
+            return x
+        if self.model_type == "transformer":
+            x = self.layer_norm(self.pos_encoding(x))
+            return self.model(x)
+        raise RuntimeError("Invalid sequence model configuration")

--- a/train.py
+++ b/train.py
@@ -82,7 +82,12 @@ def main(config_path):
                                       dataset_config=config.get('dataset_params', {}))
 
     # define model
-    model = JDCNet(num_class=1) # num_class = 1 means regression
+    model_config = config.get('model_params', {})
+    sequence_model_config = model_config.get('sequence_model', {})
+    model = JDCNet(
+        num_class=model_config.get('num_class', 1),  # num_class = 1 means regression
+        sequence_model_config=sequence_model_config,
+    )
 
     scheduler_params = {
             "max_lr": float(config['optimizer_params'].get('lr', 5e-4)),


### PR DESCRIPTION
## Summary
- add a flexible SequenceModel block that can switch between deeper BiLSTMs and Transformer encoders to improve long-term pitch continuity
- expose the temporal modelling options through `model_params` in the training configuration and document how to adjust them

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68dcd51fdf788332b5178895ef4d3c13