### PR TITLE
Add optional F0 post-processing smoothing

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -43,6 +43,16 @@ dataset_params:
   f0_params:
     bad_f0_threshold: 5
     zero_fill_value: 0.0
+    postprocessing:
+      median_filter:
+        enabled: false
+        size: 5
+      viterbi:
+        enabled: false
+        semitone_step: 1.0
+        transition_penalty: 0.5
+        observation_weight: 1.0
+        state_margin: 2.0
     # Ordered list of backend names to try when computing F0. Each entry must
     # match a key below in the ``backends`` dictionary and will be attempted in
     # sequence until one produces a valid contour.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Since both `harvest` and `dio` are relatively slow, we do have to save the compu
 
 Whenever the backend configuration changes the dataset automatically regenerates cached pitch files under backend-specific filenames and stores a small JSON metadata file alongside each cache to keep track of the extractor that produced it. Failed extraction attempts fall back to the next enabled backend until a valid contour with sufficient voiced frames is produced. If all backends fail the sample is logged and the stored F0 is left empty (zeros after post-processing), so you may want to audit those cases if they occur frequently.
 
+#### Post-processing for temporal smoothness
+
+In addition to the temporal models inside the neural network you can now apply optional smoothing to the cached F0 curves. Set `dataset_params.f0_params.postprocessing` in [`Configs/config.yml`](Configs/config.yml) to enable either a median filter (`median_filter.size`) or a lightweight Viterbi decoder (`viterbi.enabled`) that penalises large semitone jumps across contiguous voiced regions. These steps help reduce octave flips, jitter, and other unnatural transitions while preserving unvoiced regions. Both stages run after any backend finishes computing the raw contour, so you can mix and match them independently of the chosen extractor.
+
 #### Backend configuration summary
 
 - **PyWorld (harvest/dio/stonemask)** – Controlled by the `algorithm`, optional `fallback` algorithm, and `stonemask` refinement flag.


### PR DESCRIPTION
## Summary
- add configurable F0 post-processing pipeline with median filtering and Viterbi smoothing
- expose post-processing options in the default configuration and document usage

## Testing
- python -m py_compile f0_backends.py meldataset.py

------
https://chatgpt.com/codex/tasks/task_e_68dcfc94d51c83328e237a11db7b784c