### PR TITLE
Add temporal smoothing to F0 extraction

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -43,6 +43,16 @@ dataset_params:
   f0_params:
     bad_f0_threshold: 5
     zero_fill_value: 0.0
+    postprocess:
+      enabled: true
+      median:
+        enabled: true
+        size: 5
+      viterbi:
+        enabled: true
+        step_cents: 20.0
+        transition_penalty: 0.4
+        observation_sigma: 35.0
     # Ordered list of backend names to try when computing F0. Each entry must
     # match a key below in the ``backends`` dictionary and will be attempted in
     # sequence until one produces a valid contour.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Since both `harvest` and `dio` are relatively slow, we do have to save the compu
 
 Whenever the backend configuration changes the dataset automatically regenerates cached pitch files under backend-specific filenames and stores a small JSON metadata file alongside each cache to keep track of the extractor that produced it. Failed extraction attempts fall back to the next enabled backend until a valid contour with sufficient voiced frames is produced. If all backends fail the sample is logged and the stored F0 is left empty (zeros after post-processing), so you may want to audit those cases if they occur frequently.
 
+#### Temporal smoothing
+
+F0 trajectories can exhibit octave flips or jitter when extracted frame-by-frame. The new `dataset_params.f0_params.postprocess` section enables light-weight temporal smoothing that is applied after a backend returns a contour. By default we run a short median filter over each voiced segment followed by a Viterbi pass in log-frequency space. This combination preserves long-term trends while discouraging implausible octave jumps. Tweak the configuration to disable either stage, widen the median window, or adjust the Viterbi penalty/step size to suit your material.
+
 #### Backend configuration summary
 
 - **PyWorld (harvest/dio/stonemask)** – Controlled by the `algorithm`, optional `fallback` algorithm, and `stonemask` refinement flag.


### PR DESCRIPTION
## Summary
- add a configurable `F0TemporalSmoother` that performs median and Viterbi post-processing on F0 contours
- expose default smoothing parameters in `Configs/config.yml`
- document the new temporal smoothing pipeline in the README

## Testing
- python -m compileall f0_backends.py

------
https://chatgpt.com/codex/tasks/task_e_68dcfc94d51c83328e237a11db7b784c