### PR TITLE
Enable AMP training with optional gradient checkpointing

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -8,6 +8,10 @@ train_data: "Data/train_list.txt"
 val_data: "Data/val_list.txt"
 num_workers: 16
 
+training:
+  mixed_precision: true
+  gradient_checkpointing: false
+
 model_params:
   num_class: 1
   sequence_model:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Please specify the training and validation data in `config.yml` file. The data l
 
 Checkpoints and Tensorboard logs will be saved at `log_dir`. To speed up training, you may want to make `batch_size` as large as your GPU RAM can take.
 
+### Mixed precision and memory optimisations
+When running on CUDA the trainer now enables automatic mixed precision (AMP) and gradient scaling by default, significantly reducing VRAM usage while taking advantage of Tensor Cores. You can control this behaviour via the `training` section of [`Configs/config.yml`](Configs/config.yml): set `mixed_precision` to `false` to force full FP32 training or flip `gradient_checkpointing` to `true` if you want to trade a small amount of compute for lower activation memory during the forward pass.
+
 ### Sequence modelling options
 The default configuration now employs a Transformer encoder on top of the convolutional stack to provide stronger long-term temporal context and reduce octave jumps. You can switch between a deeper bidirectional LSTM and the Transformer backend by editing `model_params.sequence_model` in [Configs/config.yml](Configs/config.yml). The section exposes typical hyper-parameters (number of layers, attention heads, feed-forward width, etc.) so you can tailor the temporal model to your dataset.
 

--- a/train.py
+++ b/train.py
@@ -65,6 +65,7 @@ def main(config_path):
     train_path = config.get('train_data', None)
     val_path = config.get('val_data', None)
     num_workers = config.get('num_workers', 8)
+    training_config = config.get('training', {})
 
     train_list, val_list = get_data_path_list(train_path, val_path)
 
@@ -114,7 +115,9 @@ def main(config_path):
                         train_dataloader=train_dataloader,
                         val_dataloader=val_dataloader,
                         loss_config=loss_config,
-                        logger=logger)
+                        logger=logger,
+                        use_mixed_precision=training_config.get('mixed_precision', True),
+                        gradient_checkpointing=training_config.get('gradient_checkpointing', False))
 
     if config.get('pretrained_model', '') != '':
         trainer.load_checkpoint(config['pretrained_model'],


### PR DESCRIPTION
## Summary
- add torch.cuda.amp autocast and gradient scaling support to the Trainer, with an optional gradient checkpointing path for memory savings
- expose mixed-precision and checkpointing toggles through the training configuration and default YAML config
- document the new optimisation options in the README

## Testing
- python -m compileall trainer.py train.py

------
https://chatgpt.com/codex/tasks/task_e_68dd23a91cdc8332bb4e9dd11dd9f415