### PR TITLE
Fix pitch range notebook missing model instantiation

### DIFF
--- a/Utils/pitch_range_and_timbre_coverage.ipynb
+++ b/Utils/pitch_range_and_timbre_coverage.ipynb
@@ -442,6 +442,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = load_model()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "23179dd9",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
## Summary
- ensure the pitch range and timbre coverage notebook loads the configured checkpoint before running inference

## Testing
- not run (notebook change only)


------
https://chatgpt.com/codex/tasks/task_e_68dedc1906b883328f05da763fed8bc2